### PR TITLE
Fix input modal category

### DIFF
--- a/src/RouteSwitch.js
+++ b/src/RouteSwitch.js
@@ -21,8 +21,8 @@ const RouteSwitch = () => {
   
   const user = useAuth().user;
 
-  const isModalActive = useSelector((state) => state.modal.isActive);
-  // const isModalActive = false;
+  const isModalActive = useSelector((state) => state.modal);
+  // console.log(isModalActive);
 
   // Since I have two instances of dashboard route, it causes a bug where I'm,
   // rendering one or the other, need to delete one/consolidate
@@ -31,7 +31,7 @@ const RouteSwitch = () => {
     <>
        {user && <Sidebar />}
        {/* INCOME-EXPENSE MODULE */}
-      {isModalActive && (<InputModal />)}
+      {isModalActive.isActive && (<InputModal category={isModalActive.category} />)}
         <Routes>
           <Route
             path="/"

--- a/src/components/AddNew.js
+++ b/src/components/AddNew.js
@@ -1,22 +1,22 @@
 import React from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { select } from "../features/utilities/selectItems";
-import { changeActiveStatus } from "../features/utilities/modalSlice";
+import { isModalActive } from "../features/utilities/modalSlice";
 import InputModal from "../components/InputModal";
 
 function AddNew(props) {
   const dispatch = useDispatch();
-  const [isModalActive, setIsModalActive] = React.useState(false);
+  // const isInputModalActive = useSelector((state) => state.modal.isActive);
 
-  function checkTargetElement(e) {
-      e.preventDefault();
-  }
+
+  // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! //
+  // Correction the issue seems to be I am both rendering it here, and in RouteSwitch.
 
 
   return (
     <>
-      <svg onClick={() => setIsModalActive(true)} className="modify-entries" fill="grey" xmlns="http://www.w3.org/2000/svg" height="24"viewBox="0 -960 960 960" width="24"><path d="M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Z"/></svg>
-      {isModalActive && <InputModal setIsModalActive={setIsModalActive} cat={props.moduleName} />}
+      <svg onClick={() => dispatch(isModalActive({isActive: true, category:props.moduleName}))} className="modify-entries" fill="grey" xmlns="http://www.w3.org/2000/svg" height="24"viewBox="0 -960 960 960" width="24"><path d="M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Z"/></svg>
+      {/* {isInputModalActive && <InputModal category={props.moduleName} />} */}
       </>
   );
 }

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -6,7 +6,6 @@ import CashFlowModule from "./CashFlowModule";
 import "../styles/dashboard.css";
 // import TopOffenders from "./TopOffenders";
 import { useSelector, useDispatch, batch } from "react-redux";
-import { changeActiveStatus } from "../features/utilities/modalSlice";
 import {
   saveIncomeData,
   saveExpenseData,
@@ -122,7 +121,7 @@ const Dashboard = (props) => {
 
         <CashFlowModule cashFlow={expenseArr} moduleName="Expenses" />
 
-        <CashFlowModule cashFlow={savingsArr} moduleName="Savings" />
+        <CashFlowModule cashFlow={savingsArr} moduleName="Savings" /> 
       </section>
     </main>
   );

--- a/src/components/InputModal.js
+++ b/src/components/InputModal.js
@@ -8,11 +8,14 @@ import {
   addExpense,
   addSavings,
 } from "../features/financials/financeSlice";
+import { isModalActive } from "../features/utilities/modalSlice";
 
 function InputModal(props) {
   const user = useAuth().user.uid;
   const dispatch = useDispatch();
-  const [category, setCategory] = React.useState(props.cat);
+  const [category, setCategory] = React.useState(props.category);
+
+// console.log(category);
 
   const [input, setInput] = React.useState({
     name: "",
@@ -53,7 +56,8 @@ function InputModal(props) {
     
     updateFirebaseValues(user, category, newExpenseObj, "add");
     setInput({ name: "", amount: "", category: "" });
-    props.setIsModalActive(false);
+    // props.setIsModalActive(false);
+    dispatch(isModalActive(false));
   }
 
   // Array mapped for input selections with dynamic highlighting of each individual button
@@ -62,7 +66,7 @@ function InputModal(props) {
       <div className="modal-container">
         <form className="form-container" onSubmit={addItem}>
           <div className="cashFlow-choices">
-            <h2>{props.cat}</h2>
+            <h2>{props.category}</h2>
           </div>
           <div className="input-amounts">
             <input
@@ -86,7 +90,7 @@ function InputModal(props) {
           <div className="input-selection">
             <button
               type="button"
-              onClick={() => props.setIsModalActive(false)}
+              onClick={() => dispatch(isModalActive(false))}
               className="button"
             >
               Close

--- a/src/features/utilities/modalSlice.js
+++ b/src/features/utilities/modalSlice.js
@@ -1,19 +1,25 @@
 import {createSlice} from "@reduxjs/toolkit";
 
+// This modalSlice will have to both activate and decide which cash module category it will use
+// This is due to our modal pop up being rendered and called in RouteSwitch.js.
+// I hate this setup but I'm sure it'll work for my case temporarily.
+
 export const modalSlice = createSlice({
     name: "modal",
     initialState: {
         isActive: false,
+        category: "",
     },
     reducers: {
-        changeActiveStatus(state, action) {
-            // console.log(action.payload)
-            state.isActive = action.payload;
+        isModalActive(state, action) {
+            console.log(action.payload)
+            state.isActive = action.payload.isActive;
+            state.category = action.payload.category;
         }
     }
 });
 
 
-export const {changeActiveStatus} = modalSlice.actions;
+export const {isModalActive} = modalSlice.actions;
 
 export default modalSlice.reducer;


### PR DESCRIPTION
Made changes that allowed modal pop ups to have individual categories.

The issue was I was rendering both in RouteSwitch.js & in AddNew.js components, and was seeing the result of AddNew rather than the correct instance of RouteSwitch.

Rectified by adding both isActive & category state within the redux modalSlice so when a new entry is done, it gets passed through redux dispatch call.